### PR TITLE
test(profile): add earnings registration coverage

### DIFF
--- a/contracts/profile/src/tests/earnings.rs
+++ b/contracts/profile/src/tests/earnings.rs
@@ -1,0 +1,159 @@
+// boundless-profile: earnings registration tests.
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, BytesN as _},
+    Address, BytesN,
+};
+
+use super::common::setup;
+use crate::errors::Error;
+
+fn configure_events_contract(ctx: &super::common::TestCtx<'_>) -> Address {
+    let events = Address::generate(&ctx.env);
+    ctx.client.set_events_contract(&events);
+    events
+}
+
+#[test]
+fn register_earnings_requires_configured_events_contract() {
+    let ctx = setup(10);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    let err = ctx
+        .client
+        .try_register_earnings(&user, &token, &100_i128, &BytesN::random(&ctx.env))
+        .err()
+        .expect("events contract missing")
+        .unwrap();
+
+    assert_eq!(err, Error::EventsContractNotConfigured);
+    assert_eq!(ctx.client.get_earnings(&user, &token), 0);
+}
+
+#[test]
+fn register_earnings_records_amount_for_token() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    ctx.client
+        .register_earnings(&user, &token, &250_i128, &BytesN::random(&ctx.env));
+
+    assert_eq!(ctx.client.get_earnings(&user, &token), 250);
+}
+
+#[test]
+fn register_earnings_accumulates_per_user_and_token() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+    let other_token = Address::generate(&ctx.env);
+
+    ctx.client
+        .register_earnings(&user, &token, &100_i128, &BytesN::random(&ctx.env));
+    ctx.client
+        .register_earnings(&user, &token, &75_i128, &BytesN::random(&ctx.env));
+    ctx.client
+        .register_earnings(&user, &other_token, &30_i128, &BytesN::random(&ctx.env));
+
+    assert_eq!(ctx.client.get_earnings(&user, &token), 175);
+    assert_eq!(ctx.client.get_earnings(&user, &other_token), 30);
+}
+
+#[test]
+fn register_earnings_rejects_zero_amount() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    let err = ctx
+        .client
+        .try_register_earnings(&user, &token, &0_i128, &BytesN::random(&ctx.env))
+        .err()
+        .expect("zero amount rejected")
+        .unwrap();
+
+    assert_eq!(err, Error::InvalidAmount);
+    assert_eq!(ctx.client.get_earnings(&user, &token), 0);
+}
+
+#[test]
+fn register_earnings_rejects_negative_amount() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    let err = ctx
+        .client
+        .try_register_earnings(&user, &token, &-1_i128, &BytesN::random(&ctx.env))
+        .err()
+        .expect("negative amount rejected")
+        .unwrap();
+
+    assert_eq!(err, Error::InvalidAmount);
+    assert_eq!(ctx.client.get_earnings(&user, &token), 0);
+}
+
+#[test]
+fn register_earnings_rejects_replayed_op_id() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+    let op_id = BytesN::random(&ctx.env);
+
+    ctx.client
+        .register_earnings(&user, &token, &100_i128, &op_id);
+    let err = ctx
+        .client
+        .try_register_earnings(&user, &token, &100_i128, &op_id)
+        .err()
+        .expect("replayed op rejected")
+        .unwrap();
+
+    assert_eq!(err, Error::OpAlreadySeen);
+    assert_eq!(ctx.client.get_earnings(&user, &token), 100);
+}
+
+#[test]
+fn register_earnings_rejects_when_paused() {
+    let ctx = setup(10);
+    configure_events_contract(&ctx);
+    ctx.client.pause();
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    let err = ctx
+        .client
+        .try_register_earnings(&user, &token, &100_i128, &BytesN::random(&ctx.env))
+        .err()
+        .expect("paused contract rejected")
+        .unwrap();
+
+    assert_eq!(err, Error::Paused);
+    assert_eq!(ctx.client.get_earnings(&user, &token), 0);
+}
+
+#[test]
+fn register_earnings_requires_events_contract_auth() {
+    let ctx = setup(10);
+    let events = configure_events_contract(&ctx);
+    let user = Address::generate(&ctx.env);
+    let token = Address::generate(&ctx.env);
+
+    ctx.client
+        .register_earnings(&user, &token, &100_i128, &BytesN::random(&ctx.env));
+
+    let events_required = ctx.env.auths().iter().any(|(addr, _)| *addr == events);
+    assert!(
+        events_required,
+        "register_earnings must demand events contract authorization"
+    );
+}

--- a/contracts/profile/src/tests/mod.rs
+++ b/contracts/profile/src/tests/mod.rs
@@ -4,3 +4,4 @@
 
 mod admin;
 mod common;
+mod earnings;


### PR DESCRIPTION
Closes #30

## Summary

Adds focused native Soroban coverage for profile earnings registration.

## What changed

- Added `contracts/profile/src/tests/earnings.rs`.
- Wired it into `contracts/profile/src/tests/mod.rs`.
- Covers missing events-contract configuration, happy path registration, per-token accumulation, zero/negative amount rejection, replayed `op_id`, paused-contract rejection, and events-contract auth tracking.

## Validation

Local static validation:

- `git diff --check`

Attempted but unavailable in this Windows environment:

- `cargo test -p boundless-profile --lib earnings --no-fail-fast`
- `cargo fmt --check`

Both Cargo commands could not run because `cargo` is not installed in the local runner. The tests follow the existing `common::setup(...)`, generated client `try_*` error assertion, and `env.auths()` patterns used by the current contract tests.

## Acceptance criteria

- [x] New `tests/earnings.rs` added and wired into `tests/mod.rs`.
- [x] Happy path registration covered.
- [x] Error variants covered: `EventsContractNotConfigured`, `InvalidAmount`, `OpAlreadySeen`, and `Paused`.
- [x] Edge cases covered: zero amount, negative amount, per-token accumulation, replayed `op_id`.
- [x] Auth coverage verifies events contract authorization is requested.
- [ ] `cargo test --all` run locally; blocked by missing Cargo in this environment.

Refs #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for earnings registration, validating error handling, amount restrictions, operation ID validation, authorization requirements, and contract state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->