### PR TITLE
feat(events): add WinnerNotFound error for claim_prize validation

### DIFF
--- a/contracts/events/src/errors.rs
+++ b/contracts/events/src/errors.rs
@@ -54,7 +54,8 @@ pub enum Error {
     InvalidMilestone = 55,
     InsufficientEscrow = 56,
     WinnersAlreadySelected = 90,
-
+    WinnerNotFound = 91,
+    
     // Contributions
     BelowMinimumContribution = 57,
     InvalidContributionAmount = 58,


### PR DESCRIPTION
Add Error::WinnerNotFound to handle cases where a recipient tries to claim a prize but has no unpaid winner record in the event.

This supports the new pull‑claim payout model.

This is interlinked with https://github.com/boundlessfi/boundless-contract/issues/61