### PR TITLE
feat(events): add WinnerSelected and PrizeClaimed events for pull-claim payout model

### DIFF
--- a/contracts/events/src/events.rs
+++ b/contracts/events/src/events.rs
@@ -168,3 +168,18 @@ pub struct Migrated {
     pub from_version: String,
     pub to_version: String,
 }
+
+#[contractevent]
+pub struct WinnerSelected {
+    pub event_id: u64,
+    pub recipient: Address,
+    pub position: u32,
+    pub amount: i128,
+}
+
+#[contractevent]
+pub struct PrizeClaimed {
+    pub event_id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+}


### PR DESCRIPTION
 - WinnerSelected: emitted when winners are stored (not yet paid) in select_winners
- PrizeClaimed: emitted when a winner successfully claims their prize via claim_prize

These provide better observability for the new payout flow.

This is interlinked with https://github.com/boundlessfi/boundless-contract/issues/61