### PR TITLE
fix(events): require acceptance for manager delegation (#70)

### DIFF
--- a/contracts/events/src/errors.rs
+++ b/contracts/events/src/errors.rs
@@ -15,6 +15,7 @@ pub enum Error {
     NotAdmin = 11,
     PendingAdminMismatch = 12,
     PendingAdminExpired = 13,
+    PendingManagerMismatch = 14,
 
     TokenNotSupported = 20,
     FeeAccountMissingTrustline = 21,

--- a/contracts/events/src/event_ops.rs
+++ b/contracts/events/src/event_ops.rs
@@ -13,12 +13,14 @@ use crate::profile_client;
 use crate::storage;
 use crate::token_whitelist;
 use crate::types::{
-    CancellationBranch, CancellationState, CreateEventParams, EventRecord, EventStatus, Pillar,
-    ReleaseKind, Submission, Winner, WinnerSpec,
+    CancellationBranch, CancellationState, CreateEventParams, EventRecord, EventStatus,
+    PendingManager, Pillar, ReleaseKind, Submission, Winner, WinnerSpec,
 };
 
 const MAX_TITLE_LEN: u32 = 120;
 const MAX_WINNERS_PER_SELECT: u32 = 50;
+
+const PENDING_MANAGER_TTL_LEDGERS: u32 = 17_280;
 
 pub const MAX_APPLICANTS_PER_EVENT: u32 = 5_000;
 pub const MAX_CONTRIBUTORS_PER_EVENT: u32 = 5_000;
@@ -130,10 +132,6 @@ pub fn create_event(env: &Env, params: CreateEventParams, op_id: BytesN<32>) -> 
     storage::set_event(env, id, &record);
     storage::set_non_owner_contribution_total(env, id, 0);
 
-    if let Some(manager) = &params.manager {
-        storage::set_event_manager(env, id, manager);
-    }
-
     if is_crowdfunding {
         storage::append_winner(
             env,
@@ -159,21 +157,102 @@ pub fn create_event(env: &Env, params: CreateEventParams, op_id: BytesN<32>) -> 
     }
     .publish(env);
 
+    if let Some(manager) = &params.manager {
+        let expires_at = env
+            .ledger()
+            .sequence()
+            .saturating_add(PENDING_MANAGER_TTL_LEDGERS);
+        let pending = PendingManager {
+            target: manager.clone(),
+            expires_at_ledger: expires_at,
+        };
+        storage::set_pending_manager(env, id, &pending);
+        evt::ManagerProposed {
+            event_id: id,
+            target: manager.clone(),
+            expires_at_ledger: expires_at,
+        }
+        .publish(env);
+    }
+
     idempotency::mark_seen(env, &op_id);
     Ok(id)
 }
 
-pub fn set_manager(env: &Env, event_id: u64, new_manager: Address) -> Result<(), Error> {
+// ============================================================
+// MANAGER ROTATION (two-step propose / accept)
+// ============================================================
+pub fn propose_manager(env: &Env, event_id: u64, new_manager: Address) -> Result<(), Error> {
     admin::require_not_paused(env)?;
     let event = storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
     resolve_manager(env, event_id, &event.owner).require_auth();
-    storage::set_event_manager(env, event_id, &new_manager);
+
+    let expires_at = env
+        .ledger()
+        .sequence()
+        .saturating_add(PENDING_MANAGER_TTL_LEDGERS);
+    let pending = PendingManager {
+        target: new_manager.clone(),
+        expires_at_ledger: expires_at,
+    };
+    storage::set_pending_manager(env, event_id, &pending);
+
+    evt::ManagerProposed {
+        event_id,
+        target: new_manager,
+        expires_at_ledger: expires_at,
+    }
+    .publish(env);
+    Ok(())
+}
+
+pub fn accept_manager(env: &Env, event_id: u64) -> Result<(), Error> {
+    admin::require_not_paused(env)?;
+    storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
+
+    let pending =
+        storage::get_pending_manager(env, event_id).ok_or(Error::PendingManagerMismatch)?;
+
+    if env.ledger().sequence() > pending.expires_at_ledger {
+        storage::clear_pending_manager(env, event_id);
+        return Err(Error::PendingManagerMismatch);
+    }
+
+    pending.target.require_auth();
+
+    storage::set_event_manager(env, event_id, &pending.target);
+    storage::clear_pending_manager(env, event_id);
+
+    evt::ManagerChanged {
+        event_id,
+        new_manager: pending.target,
+    }
+    .publish(env);
+    Ok(())
+}
+
+pub fn cancel_pending_manager(env: &Env, event_id: u64) -> Result<(), Error> {
+    admin::require_not_paused(env)?;
+    let event = storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
+    resolve_manager(env, event_id, &event.owner).require_auth();
+
+    if storage::get_pending_manager(env, event_id).is_none() {
+        return Err(Error::PendingManagerMismatch);
+    }
+    storage::clear_pending_manager(env, event_id);
+
+    evt::PendingManagerCancelled { event_id }.publish(env);
     Ok(())
 }
 
 pub fn get_manager(env: &Env, event_id: u64) -> Result<Address, Error> {
     let event = storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
     Ok(resolve_manager(env, event_id, &event.owner))
+}
+
+pub fn get_pending_manager(env: &Env, event_id: u64) -> Result<Option<PendingManager>, Error> {
+    storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
+    Ok(storage::get_pending_manager(env, event_id))
 }
 
 // ============================================================

--- a/contracts/events/src/events.rs
+++ b/contracts/events/src/events.rs
@@ -21,6 +21,24 @@ pub struct EventCancelled {
 }
 
 #[contractevent]
+pub struct ManagerProposed {
+    pub event_id: u64,
+    pub target: Address,
+    pub expires_at_ledger: u32,
+}
+
+#[contractevent]
+pub struct ManagerChanged {
+    pub event_id: u64,
+    pub new_manager: Address,
+}
+
+#[contractevent]
+pub struct PendingManagerCancelled {
+    pub event_id: u64,
+}
+
+#[contractevent]
 pub struct FundsAdded {
     pub event_id: u64,
     pub contributor: Address,

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -219,12 +219,24 @@ impl EventsContract {
     // ============================================================
     // MANAGEMENT AUTHORITY (manager != funder/owner)
     // ============================================================
-    pub fn set_manager(env: Env, event_id: u64, new_manager: Address) -> Result<(), Error> {
-        event_ops::set_manager(&env, event_id, new_manager)
+    pub fn propose_manager(env: Env, event_id: u64, new_manager: Address) -> Result<(), Error> {
+        event_ops::propose_manager(&env, event_id, new_manager)
+    }
+
+    pub fn accept_manager(env: Env, event_id: u64) -> Result<(), Error> {
+        event_ops::accept_manager(&env, event_id)
+    }
+
+    pub fn cancel_pending_manager(env: Env, event_id: u64) -> Result<(), Error> {
+        event_ops::cancel_pending_manager(&env, event_id)
     }
 
     pub fn get_manager(env: Env, event_id: u64) -> Result<Address, Error> {
         event_ops::get_manager(&env, event_id)
+    }
+
+    pub fn get_pending_manager(env: Env, event_id: u64) -> Result<Option<PendingManager>, Error> {
+        event_ops::get_pending_manager(&env, event_id)
     }
 
     pub fn claim_milestone(

--- a/contracts/events/src/storage.rs
+++ b/contracts/events/src/storage.rs
@@ -6,7 +6,8 @@ use soroban_sdk::String;
 
 use crate::errors::Error;
 use crate::types::{
-    CancellationState, DataKey, EventRecord, PendingAdmin, PendingUpgrade, Submission, Winner,
+    CancellationState, DataKey, EventRecord, PendingAdmin, PendingManager, PendingUpgrade,
+    Submission, Winner,
 };
 
 // ============================================================
@@ -284,6 +285,27 @@ pub fn set_event_manager(env: &Env, id: u64, manager: &Address) {
     let key = DataKey::EventManager(id);
     env.storage().persistent().set(&key, manager);
     touch_event_persistent(env, &key);
+}
+
+pub fn get_pending_manager(env: &Env, id: u64) -> Option<PendingManager> {
+    let key = DataKey::PendingManager(id);
+    let p: Option<PendingManager> = env.storage().persistent().get(&key);
+    if p.is_some() {
+        touch_event_persistent(env, &key);
+    }
+    p
+}
+
+pub fn set_pending_manager(env: &Env, id: u64, pending: &PendingManager) {
+    let key = DataKey::PendingManager(id);
+    env.storage().persistent().set(&key, pending);
+    touch_event_persistent(env, &key);
+}
+
+pub fn clear_pending_manager(env: &Env, id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::PendingManager(id));
 }
 
 // ============================================================

--- a/contracts/events/src/tests/cancel_refund.rs
+++ b/contracts/events/src/tests/cancel_refund.rs
@@ -310,7 +310,8 @@ fn non_manager_cranks_and_finalizes_with_exact_payout_deltas() {
     let ctx = setup();
     let id = create_hackathon(&ctx);
     let manager = Address::generate(&ctx.env);
-    ctx.events.set_manager(&id, &manager);
+    ctx.events.propose_manager(&id, &manager);
+    ctx.events.accept_manager(&id);
     let p1 = Address::generate(&ctx.env);
     let p2 = Address::generate(&ctx.env);
     let p1_amount = 200_0000000_i128;

--- a/contracts/events/src/tests/cross_contract.rs
+++ b/contracts/events/src/tests/cross_contract.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
 };
 
 use super::common::drive_cancel;
+use crate::errors::Error;
 use crate::types::{CreateEventParams, EventStatus, Pillar, ReleaseKind, WinnerSpec};
 use crate::{EventsContract, EventsContractClient};
 
@@ -960,52 +961,133 @@ fn create_bounty_with_manager(ctx: &Ctx, manager: &Address) -> u64 {
     ctx.events.create_event(&params, &op_id)
 }
 
-#[test]
-fn manager_defaults_to_owner_and_override_is_recorded() {
-    let ctx = setup();
-
-    let default_id = create_bounty(&ctx);
-    assert_eq!(ctx.events.get_manager(&default_id), ctx.owner);
-
-    let manager = Address::generate(&ctx.env);
-    let managed_id = create_bounty_with_manager(&ctx, &manager);
-    assert_eq!(ctx.events.get_manager(&managed_id), manager);
-    assert_ne!(ctx.events.get_manager(&managed_id), ctx.owner);
-}
-
-#[test]
-fn manager_can_be_rotated() {
-    let ctx = setup();
-    let manager = Address::generate(&ctx.env);
-    let id = create_bounty_with_manager(&ctx, &manager);
-    assert_eq!(ctx.events.get_manager(&id), manager);
-
-    let manager2 = Address::generate(&ctx.env);
-    ctx.events.set_manager(&id, &manager2);
-    assert_eq!(ctx.events.get_manager(&id), manager2);
-}
-
-#[test]
-fn manager_override_can_select_winners() {
-    let ctx = setup();
-    let manager = Address::generate(&ctx.env);
-    let bounty_id = create_bounty_with_manager(&ctx, &manager);
-
-    let op_apply = BytesN::random(&ctx.env);
-    ctx.events
-        .apply_to_bounty(&bounty_id, &ctx.applicant, &op_apply);
-
-    let winners = soroban_sdk::vec![
+fn win_one(ctx: &Ctx) -> soroban_sdk::Vec<WinnerSpec> {
+    soroban_sdk::vec![
         &ctx.env,
         WinnerSpec {
             recipient: ctx.applicant.clone(),
             position: 1,
             reputation_bump: 0,
         },
-    ];
-    let op_select = BytesN::random(&ctx.env);
-    ctx.events.select_winners(&bounty_id, &winners, &op_select);
+    ]
+}
 
-    let event = ctx.events.get_event(&bounty_id);
-    assert_eq!(event.status, EventStatus::Completed);
+#[test]
+fn manager_defaults_to_owner_with_no_pending_proposal() {
+    let ctx = setup();
+    let default_id = create_bounty(&ctx);
+    assert_eq!(ctx.events.get_manager(&default_id), ctx.owner);
+    assert!(ctx.events.get_pending_manager(&default_id).is_none());
+}
+
+#[test]
+fn manager_named_at_creation_is_only_proposed_not_granted() {
+    let ctx = setup();
+    let manager = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &manager);
+
+    assert_eq!(ctx.events.get_manager(&id), ctx.owner);
+    let pending = ctx.events.get_pending_manager(&id).unwrap();
+    assert_eq!(pending.target, manager);
+}
+
+#[test]
+fn propose_then_accept_transfers_control() {
+    let ctx = setup();
+    let manager = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &manager);
+
+    ctx.events.accept_manager(&id);
+
+    assert_eq!(ctx.events.get_manager(&id), manager);
+    assert!(ctx.events.get_pending_manager(&id).is_none());
+}
+
+#[test]
+fn unaccepted_proposal_leaves_owner_in_authority() {
+    let ctx = setup();
+    let attacker = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &attacker);
+
+    ctx.events
+        .apply_to_bounty(&id, &ctx.applicant, &BytesN::random(&ctx.env));
+    ctx.events
+        .select_winners(&id, &win_one(&ctx), &BytesN::random(&ctx.env));
+
+    // select_winners required the owner, not the never-accepted address
+    let auths = ctx.env.auths();
+    assert_eq!(auths[0].0, ctx.owner);
+    assert_ne!(auths[0].0, attacker);
+}
+
+#[test]
+fn accepted_manager_holds_select_winners_authority() {
+    let ctx = setup();
+    let manager = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &manager);
+    ctx.events.accept_manager(&id);
+
+    ctx.events
+        .apply_to_bounty(&id, &ctx.applicant, &BytesN::random(&ctx.env));
+    ctx.events
+        .select_winners(&id, &win_one(&ctx), &BytesN::random(&ctx.env));
+
+    let auths = ctx.env.auths();
+    assert_eq!(auths[0].0, manager);
+    assert_eq!(ctx.events.get_event(&id).status, EventStatus::Completed);
+}
+
+#[test]
+fn manager_can_be_rotated_via_propose_accept() {
+    let ctx = setup();
+    let manager = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &manager);
+    ctx.events.accept_manager(&id);
+    assert_eq!(ctx.events.get_manager(&id), manager);
+
+    let manager2 = Address::generate(&ctx.env);
+    ctx.events.propose_manager(&id, &manager2);
+    assert_eq!(ctx.events.get_manager(&id), manager);
+    ctx.events.accept_manager(&id);
+    assert_eq!(ctx.events.get_manager(&id), manager2);
+}
+
+#[test]
+fn cancel_pending_manager_vetoes_a_proposal() {
+    let ctx = setup();
+    let attacker = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &attacker);
+    assert!(ctx.events.get_pending_manager(&id).is_some());
+
+    ctx.events.cancel_pending_manager(&id);
+    assert!(ctx.events.get_pending_manager(&id).is_none());
+    assert_eq!(ctx.events.get_manager(&id), ctx.owner);
+}
+
+#[test]
+fn accept_with_no_proposal_reverts() {
+    let ctx = setup();
+    let id = create_bounty(&ctx);
+    let res = ctx.events.try_accept_manager(&id);
+    assert_eq!(res, Err(Ok(Error::PendingManagerMismatch)));
+}
+
+#[test]
+fn expired_proposal_cannot_be_accepted() {
+    use soroban_sdk::testutils::Ledger as _;
+
+    let ctx = setup();
+    let manager = Address::generate(&ctx.env);
+    let id = create_bounty_with_manager(&ctx, &manager);
+
+    // advance past the acceptance window (PENDING_MANAGER_TTL_LEDGERS)
+    ctx.env.ledger().with_mut(|li| {
+        li.sequence_number += 20_000;
+    });
+
+    let res = ctx.events.try_accept_manager(&id);
+    assert_eq!(res, Err(Ok(Error::PendingManagerMismatch)));
+    assert_eq!(ctx.events.get_manager(&id), ctx.owner);
+    ctx.events.cancel_pending_manager(&id);
+    assert!(ctx.events.get_pending_manager(&id).is_none());
 }

--- a/contracts/events/src/types.rs
+++ b/contracts/events/src/types.rs
@@ -195,6 +195,9 @@ pub enum DataKey {
 
     // Appended in 1.2.0 to preserve existing key discriminants.
     NonOwnerContributionTotal(u64),
+
+    // Appended for two-step manager rotation to preserve key discriminants.
+    PendingManager(u64),
 }
 
 // ============================================================
@@ -203,6 +206,16 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PendingAdmin {
+    pub target: Address,
+    pub expires_at_ledger: u32,
+}
+
+// ============================================================
+// PENDING MANAGER payload (target + expiry ledger)
+// ============================================================
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingManager {
     pub target: Address,
     pub expires_at_ledger: u32,
 }

--- a/docs/mainnet-deploy-runbook.md
+++ b/docs/mainnet-deploy-runbook.md
@@ -328,7 +328,7 @@ stellar contract invoke \
 
 Sign `/tmp/events-emergency-pause.xdr` sequentially with two signers, submit with `stellar tx send`, then read `is_paused` back as `true`.
 
-Pause stops event-lifecycle mutations guarded by `require_not_paused`, including `create_event`, `add_funds`, `set_manager`, `start_cancel`, `process_cancel_batch`, `finalize_cancel`, `select_winners`, `claim_milestone`, `apply_to_bounty`, `withdraw_application`, `submit`, and `withdraw_submission`. Reads continue.
+Pause stops event-lifecycle mutations guarded by `require_not_paused`, including `create_event`, `add_funds`, `propose_manager`, `accept_manager`, `cancel_pending_manager`, `start_cancel`, `process_cancel_batch`, `finalize_cancel`, `select_winners`, `claim_milestone`, `apply_to_bounty`, `withdraw_application`, `submit`, and `withdraw_submission`. Reads continue.
 
 Pause intentionally does **not** block admin recovery and governance entrypoints such as `propose_upgrade`, `apply_upgrade`, `cancel_pending_upgrade`, `migrate`, configuration changes, token-list changes, admin rotation, or `unpause`. This is why the 1.1.0 → 1.2.0 upgrade can remain paused through its timelock.
 


### PR DESCRIPTION
Closes #70

## Problem
`create_event(params.manager)` and `set_manager` granted privileged authority (`select_winners`, cancel, manager rotation) to an address that never authorized. A typo, wrong-network address, or a malicious frontend swapping `params.manager` at signing time could:
- **lock the owner out permanently** — only the current manager can rotate the manager, so pointing it at a dead/unowned address freezes the event and its escrow; or
- **hand escrow-draining `select_winners` authority to an attacker** with no further owner sign-off (non-crowdfunding pillars).

Root cause: transferring a privileged role to an address that never proved it controls the key.

## Fix
Two-step propose/accept, mirroring the existing `set_admin`/`accept_admin` rotation:

- `propose_manager(event_id, new_manager)` — current authority (the manager, or the owner when none is set) records a pending proposal with a short expiry. **No authority transfers.** Emits `ManagerProposed`.
- `accept_manager(event_id)` — the proposed address must `require_auth()` to accept before the role transfers. Emits `ManagerChanged` (which also closes the missing `set_manager` storage-change event flagged by Scout).
- `cancel_pending_manager(event_id)` — current authority vetoes a pending proposal.
- `create_event` now only **proposes** `params.manager`; authority resolves to the owner (via `resolve_manager`) until acceptance, so the owner is never locked out.
- `get_pending_manager(event_id)` read added.
- `set_manager` removed (its instant-transfer semantics were the vulnerability).

The only path that grants manager authority (`accept_manager`) calls `pending.target.require_auth()` immediately before writing the manager, so a never-accepting address gains nothing and the owner is never displaced.

## Storage
Extended append-only (no reorder): new `DataKey::PendingManager(u64)` and `PendingManager { target, expires_at_ledger }`.

## Tests
Rewrote the manager suite in `cross_contract.rs`:
- default-to-owner with no pending proposal
- manager named at creation is only proposed, not granted
- propose → accept transfers control
- unaccepted proposal leaves the owner in authority (verified via `env.auths()`)
- accepted manager holds `select_winners` authority
- rotation via propose/accept
- `cancel_pending_manager` vetoes a proposal
- accept with no proposal reverts
- expired proposal cannot be accepted

Updated the one prior `set_manager` call in `cancel_refund.rs`, and the pause-guarded-function list in `docs/mainnet-deploy-runbook.md`.

## Verification
- `cargo test --all` — 269 passed (203 events + 66 profile)
- `cargo build --release --target wasm32v1-none` — builds
- `cargo fmt --check` and `cargo clippy -p boundless-events` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure, two-step manager transfer process with proposal, acceptance, and cancellation.
  * Added expiration for pending manager changes.
  * Added visibility into pending manager proposals.
  * Added events for manager proposals, successful changes, and cancellations.
  * Initial event managers now require acceptance before becoming active.

* **Breaking Changes**
  * Removed direct manager assignment in favor of the proposal and acceptance workflow.

* **Documentation**
  * Updated deployment guidance to reflect the new manager controls and pause behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->