### PR TITLE
feat(events): stop enforcing the submission deadline on-chain

### DIFF
--- a/contracts/events/src/bounty.rs
+++ b/contracts/events/src/bounty.rs
@@ -28,7 +28,7 @@ pub fn apply(
     admin::require_not_paused(env)?;
 
     let event = storage::get_event(env, bounty_id).ok_or(Error::EventNotFound)?;
-    require_active_bounty(env, &event)?;
+    require_active_bounty(&event)?;
 
     applicant.require_auth();
     idempotency::require_unseen(env, &applicant, &op_id)?;
@@ -61,7 +61,7 @@ pub fn withdraw_application(
     admin::require_not_paused(env)?;
 
     let event = storage::get_event(env, bounty_id).ok_or(Error::EventNotFound)?;
-    require_active_bounty(env, &event)?;
+    require_active_bounty(&event)?;
 
     applicant.require_auth();
     idempotency::require_unseen(env, &applicant, &op_id)?;
@@ -85,17 +85,12 @@ pub fn withdraw_application(
 // ============================================================
 // HELPERS
 // ============================================================
-fn require_active_bounty(env: &Env, event: &EventRecord) -> Result<(), Error> {
+fn require_active_bounty(event: &EventRecord) -> Result<(), Error> {
     if !matches!(event.pillar, Pillar::Bounty) {
         return Err(Error::InvalidPillar);
     }
     if !matches!(event.status, EventStatus::Active) {
         return Err(Error::EventNotActive);
-    }
-    if let Some(deadline) = event.deadline {
-        if deadline <= env.ledger().timestamp() {
-            return Err(Error::DeadlinePassed);
-        }
     }
     Ok(())
 }

--- a/contracts/events/src/crowdfunding.rs
+++ b/contracts/events/src/crowdfunding.rs
@@ -11,10 +11,6 @@ pub fn validate_create(_env: &Env, record: &EventRecord, _owner: &Address) -> Re
         _ => return Err(Error::InvalidReleaseKind),
     }
 
-    if record.deadline.is_none() {
-        return Err(Error::DeadlineRequired);
-    }
-
     if record.winner_distribution.len() != 1 {
         return Err(Error::InvalidDistribution);
     }

--- a/contracts/events/src/errors.rs
+++ b/contracts/events/src/errors.rs
@@ -29,9 +29,8 @@ pub enum Error {
     InvalidReleaseKind = 33,
     InvalidDistribution = 34,
     InvalidBudget = 35,
-    DeadlineRequired = 36,
-    DeadlinePassed = 37,
-    DeadlineMustBeFuture = 38,
+    // 36-38 retired: deadline enforcement removed (submission windows are an
+    // off-chain/backend concern; the contract no longer gates on deadline).
     TitleTooLong = 39,
 
     ApplicantAlreadyApplied = 40,

--- a/contracts/events/src/event_ops.rs
+++ b/contracts/events/src/event_ops.rs
@@ -81,12 +81,6 @@ pub fn create_event(env: &Env, params: CreateEventParams, op_id: BytesN<32>) -> 
         return Err(Error::DistributionMismatch);
     }
 
-    if let Some(deadline) = params.deadline {
-        if deadline <= env.ledger().timestamp() {
-            return Err(Error::DeadlineMustBeFuture);
-        }
-    }
-
     if let Some(bps) = params.fee_bps_override {
         if bps > MAX_FEE_BPS {
             return Err(Error::InvalidFeeBps);
@@ -544,11 +538,6 @@ pub fn submit(
     if matches!(event.pillar, Pillar::Crowdfunding) {
         return Err(Error::InvalidPillar);
     }
-    if let Some(deadline) = event.deadline {
-        if deadline <= env.ledger().timestamp() {
-            return Err(Error::DeadlinePassed);
-        }
-    }
 
     applicant.require_auth();
     idempotency::require_unseen(env, &applicant, &op_id)?;
@@ -611,11 +600,6 @@ pub fn withdraw_submission(
     let event = storage::get_event(env, event_id).ok_or(Error::EventNotFound)?;
     if !matches!(event.status, EventStatus::Active) {
         return Err(Error::EventNotActive);
-    }
-    if let Some(deadline) = event.deadline {
-        if deadline <= env.ledger().timestamp() {
-            return Err(Error::DeadlinePassed);
-        }
     }
 
     applicant.require_auth();

--- a/contracts/events/src/hackathon.rs
+++ b/contracts/events/src/hackathon.rs
@@ -9,8 +9,5 @@ pub fn validate_create(_env: &Env, record: &EventRecord, _owner: &Address) -> Re
     if !matches!(record.release_kind, ReleaseKind::Single) {
         return Err(Error::InvalidReleaseKind);
     }
-    if record.deadline.is_none() {
-        return Err(Error::DeadlineRequired);
-    }
     Ok(())
 }

--- a/contracts/events/src/tests/bounty_pillar.rs
+++ b/contracts/events/src/tests/bounty_pillar.rs
@@ -281,24 +281,6 @@ fn apply_on_completed_event_reverts() {
 }
 
 #[test]
-fn apply_after_deadline_reverts() {
-    let ctx = setup();
-    let deadline = ctx.env.ledger().timestamp() + 100;
-    let bounty_id = create_bounty_with_deadline(&ctx, deadline);
-
-    ctx.env.ledger().with_mut(|li| {
-        li.timestamp = deadline;
-    });
-
-    let op_id = BytesN::random(&ctx.env);
-    let err = expect_op_err(
-        ctx.events
-            .try_apply_to_bounty(&bounty_id, &ctx.applicant, &op_id),
-    );
-    assert_eq!(err, Error::DeadlinePassed);
-}
-
-#[test]
 fn apply_when_paused_reverts() {
     let ctx = setup();
     let bounty_id = create_bounty(&ctx);

--- a/contracts/events/src/tests/crowdfunding.rs
+++ b/contracts/events/src/tests/crowdfunding.rs
@@ -159,27 +159,6 @@ fn create_rejects_single_release_kind() {
 }
 
 #[test]
-fn create_rejects_missing_deadline() {
-    let ctx = setup();
-    let params = CreateEventParams {
-        pillar: Pillar::Crowdfunding,
-        owner: ctx.builder.clone(),
-        token: ctx.token_addr.clone(),
-        total_budget: FUNDING_GOAL,
-        release_kind: ReleaseKind::Multi(3),
-        content_uri: String::from_str(&ctx.env, "uri"),
-        title: String::from_str(&ctx.env, "Bad CF"),
-        deadline: None,
-        winner_distribution: single_dist_100_at_1(&ctx.env),
-        fee_bps_override: None,
-        manager: None,
-    };
-    let op = BytesN::random(&ctx.env);
-    let res = ctx.events.try_create_event(&params, &op);
-    assert!(res.is_err());
-}
-
-#[test]
 fn create_rejects_distribution_with_multiple_positions() {
     let ctx = setup();
     let mut dist = Map::new(&ctx.env);

--- a/contracts/events/src/tests/hackathon_pillar.rs
+++ b/contracts/events/src/tests/hackathon_pillar.rs
@@ -172,48 +172,6 @@ fn create_rejects_multi_release_kind() {
     assert!(res.is_err(), "hackathon must use Single release");
 }
 
-#[test]
-fn create_rejects_missing_deadline() {
-    let ctx = setup();
-    let params = CreateEventParams {
-        pillar: Pillar::Hackathon,
-        owner: ctx.owner.clone(),
-        token: ctx.token_addr.clone(),
-        total_budget: TOTAL_BUDGET,
-        release_kind: ReleaseKind::Single,
-        content_uri: String::from_str(&ctx.env, "uri"),
-        title: String::from_str(&ctx.env, "Hackathon"),
-        deadline: None,
-        winner_distribution: single_winner_dist(&ctx.env),
-        fee_bps_override: None,
-        manager: None,
-    };
-    let op = BytesN::random(&ctx.env);
-    let res = ctx.events.try_create_event(&params, &op);
-    assert!(res.is_err(), "hackathon requires a submission deadline");
-}
-
-#[test]
-fn create_rejects_past_deadline() {
-    let ctx = setup();
-    let params = CreateEventParams {
-        pillar: Pillar::Hackathon,
-        owner: ctx.owner.clone(),
-        token: ctx.token_addr.clone(),
-        total_budget: TOTAL_BUDGET,
-        release_kind: ReleaseKind::Single,
-        content_uri: String::from_str(&ctx.env, "uri"),
-        title: String::from_str(&ctx.env, "Hackathon"),
-        deadline: Some(ctx.env.ledger().timestamp()),
-        winner_distribution: single_winner_dist(&ctx.env),
-        fee_bps_override: None,
-        manager: None,
-    };
-    let op = BytesN::random(&ctx.env);
-    let res = ctx.events.try_create_event(&params, &op);
-    assert!(res.is_err(), "deadline must be in the future");
-}
-
 // ============================================================
 // submit (open submission model)
 // ============================================================
@@ -250,21 +208,6 @@ fn resubmit_keeps_original_timestamp_and_updates_uri() {
     let second = ctx.events.get_submission(&id, &ctx.applicant);
     assert_eq!(second.content_uri, uri_b);
     assert_eq!(second.submitted_at, first_time);
-}
-
-#[test]
-fn submit_after_deadline_reverts() {
-    let ctx = setup();
-    let id = create_hackathon(&ctx);
-
-    ctx.env.ledger().with_mut(|li| {
-        li.timestamp += 2 * 86_400;
-    });
-
-    let uri = String::from_str(&ctx.env, "ipfs://Qm.../late.json");
-    let op = BytesN::random(&ctx.env);
-    let res = ctx.events.try_submit(&id, &ctx.applicant, &uri, &op);
-    assert!(res.is_err(), "submission after the deadline must revert");
 }
 
 #[test]


### PR DESCRIPTION
## Why

The submission deadline was enforced by the contract, but it gates nothing the contract is actually responsible for — and it was **immutable on-chain**, so the contract couldn't support the extensions organizers do routinely.

Walking the cases (verified in code):
- **Funds:** no money path reads `deadline`. Since #61, payout/refund liveness is anchored to *selection* time (`PRIZE_CLAIM_WINDOW_SECS`), not the deadline.
- **Winner eligibility:** `select_winners` never consults submissions — winners are the manager's discretion, picked by address. So a late submission row is **inert**.
- **Storage abuse:** permissionless hackathon `submit` is bounded by the #86 count cap (5,000), not the deadline.

So a submission window — with its extensions, grace periods, cutoffs — is a **backend/product concern**. The chain keeps only what it must: escrow custody, the count cap, and discretionary winner selection.

## Change

Remove the enforcement only:
- delete the deadline rejection in `submit`, `withdraw_submission`, and bounty `apply`;
- delete the create-time `DeadlineMustBeFuture` check;
- drop the required-deadline check from `hackathon`/`crowdfunding` `validate_create`.

**Keep `EventRecord.deadline`** as advisory metadata — still stored, still emitted on `EventCreated`, now owned by the backend. This means:
- **No storage-layout change, no migration, no ABI break** — the field and `CreateEventParams` are untouched.
- Every submission still records `submitted_at`, so you retain on-chain proof of *when* something was submitted; the backend compares it to whatever the (flexible, extendable) deadline is.

The now-dead `DeadlineRequired` / `DeadlinePassed` / `DeadlineMustBeFuture` variants are retired, which also frees **3 slots** against the 50-case error-enum cap that #86/#88 kept bumping into.

## Verification

- `cargo test --workspace`: 220 events + 66 profile green (removed the 5 tests that asserted the deleted behavior)
- `make build` (stellar-cli 27): events wasm 55,742 B (< 64 KB)
- `cargo fmt --check` clean

## Note

Physically removing the `deadline` field later (if ever wanted) is a separate storage-migration task and deliberately not coupled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event creation no longer requires a deadline for crowdfunding campaigns or hackathons.
  * Submissions, applications, and withdrawals are no longer blocked after an event deadline.
  * Bounties remain available for applications while active, regardless of the original deadline.

* **Bug Fixes**
  * Removed outdated deadline-related validation errors and restrictions across event workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->