### PR TITLE
chore(events): bump to 1.5.0 (deadline enforcement removed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-events"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "boundless-profile",
  "soroban-sdk",

--- a/contracts/events/Cargo.toml
+++ b/contracts/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boundless-events"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 publish = false
 

--- a/contracts/events/src/admin.rs
+++ b/contracts/events/src/admin.rs
@@ -15,7 +15,7 @@ const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
 const UPGRADE_TIMELOCK_LEDGERS: u32 = 0;
 const PENDING_UPGRADE_TTL_LEDGERS: u32 = 518_400;
 
-pub const INITIAL_VERSION: &str = "1.4.0";
+pub const INITIAL_VERSION: &str = "1.5.0";
 
 // ============================================================
 // INITIALIZATION

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -24,7 +24,7 @@ mod tests;
 use crate::errors::Error;
 use crate::types::*;
 
-contractmeta!(key = "version", val = "1.4.0");
+contractmeta!(key = "version", val = "1.5.0");
 contractmeta!(
     key = "description",
     val = "Boundless events contract: hackathon, bounty, grant + escrow"

--- a/contracts/events/src/tests/admin.rs
+++ b/contracts/events/src/tests/admin.rs
@@ -19,7 +19,7 @@ fn initializes_with_expected_config() {
     assert_eq!(ctx.client.get_fee_bps(), 250);
     assert_eq!(ctx.client.get_profile_contract(), ctx.profile_contract);
     assert_eq!(ctx.client.is_paused(), false);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.4.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
     assert_eq!(ctx.client.get_pending_upgrade(), None);
     assert_eq!(ctx.client.get_migrated_to_version(), None);
 }
@@ -96,7 +96,7 @@ fn apply_upgrade_before_timelock_reverts() {
         .expect("timelock blocks")
         .unwrap();
     assert_eq!(err, Error::UpgradeTimelockNotElapsed);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.4.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn cancel_pending_upgrade_clears_proposal() {
 
     ctx.client.cancel_pending_upgrade();
     assert_eq!(ctx.client.get_pending_upgrade(), None);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.4.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn migrate_marks_current_version_and_blocks_replay() {
     ctx.client.migrate();
     assert_eq!(
         ctx.client.get_migrated_to_version(),
-        Some(String::from_str(&ctx.env, "1.4.0"))
+        Some(String::from_str(&ctx.env, "1.5.0"))
     );
 
     let err = ctx


### PR DESCRIPTION
#99 removed on-chain submission-deadline enforcement (a real behavior change) but didn't bump the version. Bump events **1.4.0 → 1.5.0** across `INITIAL_VERSION`, `contractmeta`, and the Cargo package version so the next testnet upgrade reports a coherent `version()`. Profile untouched by #99 → stays 1.2.0.

version()-asserting admin tests updated; admin suite green, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)