### PR TITLE
chore(events): bump to 1.6.0 to match on-chain upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-events"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "boundless-profile",
  "soroban-sdk",

--- a/contracts/events/Cargo.toml
+++ b/contracts/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boundless-events"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 publish = false
 

--- a/contracts/events/src/admin.rs
+++ b/contracts/events/src/admin.rs
@@ -15,7 +15,7 @@ const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
 const UPGRADE_TIMELOCK_LEDGERS: u32 = 0;
 const PENDING_UPGRADE_TTL_LEDGERS: u32 = 518_400;
 
-pub const INITIAL_VERSION: &str = "1.5.0";
+pub const INITIAL_VERSION: &str = "1.6.0";
 
 // ============================================================
 // INITIALIZATION

--- a/contracts/events/src/lib.rs
+++ b/contracts/events/src/lib.rs
@@ -24,7 +24,7 @@ mod tests;
 use crate::errors::Error;
 use crate::types::*;
 
-contractmeta!(key = "version", val = "1.5.0");
+contractmeta!(key = "version", val = "1.6.0");
 contractmeta!(
     key = "description",
     val = "Boundless events contract: hackathon, bounty, grant + escrow"

--- a/contracts/events/src/tests/admin.rs
+++ b/contracts/events/src/tests/admin.rs
@@ -19,7 +19,7 @@ fn initializes_with_expected_config() {
     assert_eq!(ctx.client.get_fee_bps(), 250);
     assert_eq!(ctx.client.get_profile_contract(), ctx.profile_contract);
     assert_eq!(ctx.client.is_paused(), false);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.6.0"));
     assert_eq!(ctx.client.get_pending_upgrade(), None);
     assert_eq!(ctx.client.get_migrated_to_version(), None);
 }
@@ -96,7 +96,7 @@ fn apply_upgrade_before_timelock_reverts() {
         .expect("timelock blocks")
         .unwrap();
     assert_eq!(err, Error::UpgradeTimelockNotElapsed);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.6.0"));
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn cancel_pending_upgrade_clears_proposal() {
 
     ctx.client.cancel_pending_upgrade();
     assert_eq!(ctx.client.get_pending_upgrade(), None);
-    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.5.0"));
+    assert_eq!(ctx.client.version(), String::from_str(&ctx.env, "1.6.0"));
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn migrate_marks_current_version_and_blocks_replay() {
     ctx.client.migrate();
     assert_eq!(
         ctx.client.get_migrated_to_version(),
-        Some(String::from_str(&ctx.env, "1.5.0"))
+        Some(String::from_str(&ctx.env, "1.6.0"))
     );
 
     let err = ctx


### PR DESCRIPTION
The testnet events contract was upgraded to 1.6.0 on 2026-07-28 (wasm hash bfc1710911afbf150cc6e48e9264e1def81cde954bad8ecbf42dc96954b11f5d, see deployments/testnet-upgrades.jsonl), but the source still declared 1.5.0. Bump events 1.5.0 -> 1.6.0 across INITIAL_VERSION, contractmeta, and the Cargo package version so source and chain agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the events contract version from 1.5.0 to 1.6.0.
  * Updated version metadata and initialization values to reflect the new release.
  * Updated related validation checks to expect version 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->