### PR TITLE
fix(ci): assert the built version instead of pinning it to a fixture hash

### DIFF
--- a/contracts/compatibility/fixtures/manifest.json
+++ b/contracts/compatibility/fixtures/manifest.json
@@ -47,7 +47,8 @@
       "soroban_sdk": "27.0.0",
       "protocol": 27,
       "runtime_version": "1.5.0",
-      "contractmeta_version": "1.5.0"
+      "contractmeta_version": "1.5.0",
+      "note": "Historical SDK 27 fixture, kept byte-for-byte as the 'new' side of the storage-compatibility tests. It is not expected to match a current build: contractmeta is embedded in the wasm, so every runtime version bump changes the hash. The build gate asserts contractmeta matches INITIAL_VERSION instead."
     },
     {
       "file": "profile-1.2.0-sdk27.wasm",

--- a/scripts/test-sdk27-compat.sh
+++ b/scripts/test-sdk27-compat.sh
@@ -24,6 +24,33 @@ check_hash() {
     fi
 }
 
+meta_version() {
+    stellar -q contract info meta --wasm "$1" --output json \
+        | jq -er '.[] | select(.sc_meta_v0.key == "version") | .sc_meta_v0.val'
+}
+
+# The version the source claims, from `pub const INITIAL_VERSION`.
+source_version() {
+    local file="$1" version
+    version="$(sed -n 's/^pub const INITIAL_VERSION: &str = "\(.*\)";$/\1/p' "$file")"
+    if [ -z "$version" ]; then
+        echo "no INITIAL_VERSION found in $file" >&2
+        exit 1
+    fi
+    printf '%s\n' "$version"
+}
+
+check_declared_version() {
+    local wasm="$1" expected="$2" actual
+    actual="$(meta_version "$wasm")"
+    if [ "$actual" != "$expected" ]; then
+        echo "declared version mismatch for $wasm" >&2
+        echo "  contractmeta:              $actual" >&2
+        echo "  INITIAL_VERSION in source: $expected" >&2
+        exit 1
+    fi
+}
+
 rustc --version | grep -q '^rustc 1\.93\.0 ' || {
     echo "Rust 1.93.0 is required" >&2
     exit 1
@@ -38,10 +65,7 @@ while IFS=$'\t' read -r file expected; do
 done < <(jq -r '.wasm[] | [.file, .sha256] | @tsv' "$MANIFEST")
 
 while IFS=$'\t' read -r file expected; do
-    actual="$(
-        stellar -q contract info meta --wasm "$FIXTURES/$file" --output json \
-            | jq -er '.[] | select(.sc_meta_v0.key == "version") | .sc_meta_v0.val'
-    )"
+    actual="$(meta_version "$FIXTURES/$file")"
     if [ "$actual" != "$expected" ]; then
         echo "contractmeta version mismatch for $file" >&2
         echo "expected: $expected" >&2
@@ -101,10 +125,18 @@ case "$verify_build" in
             exit 1
         }
 
-        events_hash="$(jq -r '.wasm[] | select(.file == "events-1.5.0-sdk27.wasm") | .sha256' "$MANIFEST")"
-        profile_hash="$(jq -r '.wasm[] | select(.file == "profile-1.2.0-sdk27.wasm") | .sha256' "$MANIFEST")"
-        check_hash "$EVENTS_WASM" "$events_hash"
-        check_hash "$PROFILE_WASM" "$profile_hash"
+        # Assert the built artifact declares the version its source claims,
+        # rather than pinning it to a fixture hash. contractmeta! is embedded
+        # in the wasm, so a fixture pin is unsatisfiable the moment the runtime
+        # version moves past that fixture's — it went red on the 1.6.0 bump and
+        # would go red on every bump after.
+        #
+        # This catches the failure the pin was really guarding against. The two
+        # version declarations are independent and have drifted before:
+        # fixtures/events-1.3.0-sdk23.wasm reports contractmeta 1.2.0 against a
+        # 1.3.0 runtime, recorded in the manifest note for that entry.
+        check_declared_version "$EVENTS_WASM" "$(source_version "$ROOT/contracts/events/src/admin.rs")"
+        check_declared_version "$PROFILE_WASM" "$(source_version "$ROOT/contracts/profile/src/admin.rs")"
         ;;
     *)
         echo "VERIFY_SDK27_BUILD must be 0 or 1" >&2


### PR DESCRIPTION
The `build` workflow has been red on `testnet` since 30 July. This unblocks it.

## What was wrong

With `VERIFY_SDK27_BUILD=1`, `scripts/test-sdk27-compat.sh` asserted that a freshly built `boundless_events.wasm` hashes to the pinned `events-1.5.0-sdk27.wasm` fixture:

```
hash mismatch for target/wasm32v1-none/release/boundless_events.wasm
expected: 31b27e9d…   (events-1.5.0-sdk27.wasm fixture)
actual:   a56e3477…   (testnet HEAD, 1.6.0)
```

`contractmeta!(key = "version", …)` is embedded in the wasm, so that assertion stopped being satisfiable the moment the runtime version moved to 1.6.0 in #105. Reproducible on `testnet` at `ec2ae0c` with nothing else applied.

| Branch | Commit | `verify-build` |
| --- | --- | --- |
| `testnet` | `b12a976` bump to 1.6.0 | ✅ |
| `testnet` | `ec2ae0c` gate sdk 27 storage compatibility (#102) | ❌ |
| `testnet` | `a7539bf` sql mod | ❌ |

## Why not just re-pin the hash

It would go green until the next version bump and then fail identically. The fixture is a *historical* artifact — it is the "new" side of the SDK 23 → SDK 27 storage tests — so by design it drifts from HEAD as soon as HEAD moves on. Pinning the current build to it couples "is this build sound" to "is the version still 1.5.0".

## What it asserts now

The property the pin was really guarding: **a shipped artifact declares the version its source claims.** `contractmeta!` and `INITIAL_VERSION` are independent declarations, and they have drifted before — `fixtures/events-1.3.0-sdk23.wasm` reports contractmeta `1.2.0` against a `1.3.0` runtime, which the manifest already records as a known defect. That is exactly the bug class this now catches, and it survives version bumps.

Verified negatively rather than assumed. Reverting events `contractmeta` to `1.5.0` against a `1.6.0` source:

```
declared version mismatch for target/wasm32v1-none/release/boundless_events.wasm
  contractmeta:              1.5.0
  INITIAL_VERSION in source: 1.6.0
```

## Unchanged

Fixture hashes stay pinned byte-for-byte, snapshot provenance checks are untouched, and the compatibility suite itself is not modified. The only other change is a `note` on the `events-1.5.0-sdk27.wasm` manifest entry recording that it is historical and not expected to match a current build, so the next person does not re-pin it.

## Verification

Every step the `build` workflow runs, locally on this branch with the required toolchain (rustc 1.93.0, Stellar CLI 27.0.0):

- `VERIFY_SDK27_BUILD=1 ./scripts/test-sdk27-compat.sh` — passes, including the 3 compatibility tests
- `stellar contract build --locked` — green, both wasms under the 64 KB ceiling
- `cargo test` — 225 events, 66 profile, 3 compatibility
- `cargo fmt --check` — clean
- `./scripts/test-mainnet-upgrade-guards.sh` — passes
- `bash -n` on `deploy_mainnet.sh` and `scripts/capture-mainnet-compat-snapshot.sh`

## Note

#120 sits behind this. It carries the same red for the same pre-existing reason, and will go green once this merges and it rebases.
